### PR TITLE
Run the distribution more than once

### DIFF
--- a/distribute-values.rb
+++ b/distribute-values.rb
@@ -94,10 +94,10 @@ end
 
 # Write the result to a CSV file.
 CSV.open(path, "wb") do |csv|
-  results.each do |r|
+  results.each_with_index do |r, i|
     r.each do |row|
       csv << row
     end
-    csv << []
+    csv << [] unless i >= runs - 1
   end
 end

--- a/distribute-values.rb
+++ b/distribute-values.rb
@@ -9,7 +9,7 @@
 # The result will be saved in a CSV file.
 require "csv"
 
-rows = cols = values = 0
+rows = cols = values = runs = 0
 path = ""
 
 loop do
@@ -40,6 +40,13 @@ loop do
 end
 
 loop do
+  puts "Number of times to run the distribution?"
+  runs = gets.chomp.to_i
+  break if runs > 0
+  puts "Invalid number of runs, sorry."
+end
+
+loop do
   puts "Where should I save the result?"
   path = gets.chomp
 
@@ -55,9 +62,13 @@ loop do
 end
 
 # Create a 2D array filled with nils to store the result.
-result = []
-rows.times do
-  result << Array.new(cols)
+results = []
+runs.times do
+  r = []
+  rows.times do
+    r << Array.new(cols)
+  end
+  results << r
 end
 
 # For each value, choose a cell at random. If it's empty,
@@ -65,15 +76,17 @@ end
 # cell randomly until an empty one is found.
 #
 # Repeat until all values have been distributed.
-values.times do |i|
-  ((rows * cols) / values).times do
-    loop do
-      row = Random.rand(rows)
-      col = Random.rand(cols)
+results.each do |r|
+  values.times do |i|
+    ((rows * cols) / values).times do
+      loop do
+        row = Random.rand(rows)
+        col = Random.rand(cols)
 
-      if result[row][col].nil?
-        result[row][col] = i+1
-        break
+        if r[row][col].nil?
+          r[row][col] = i+1
+          break
+        end
       end
     end
   end
@@ -81,7 +94,10 @@ end
 
 # Write the result to a CSV file.
 CSV.open(path, "wb") do |csv|
-  result.each do |row|
-    csv << row
+  results.each do |r|
+    r.each do |row|
+      csv << row
+    end
+    csv << []
   end
 end


### PR DESCRIPTION
This PR implements the suggestion in https://github.com/rjlarosa/scripts/issues/2#issuecomment-426162860. It will now prompt you for the number of times to run the distribution:

```
$ ./distribute-values.rb 
Number of rows?
5
Number of columns?
20
Number of values to distribute?
5
Number of times to run the distribution?
3
Where should I save the result?
out.csv
```

The output looks like this:

<img width="360" alt="screen shot 2018-10-03 at 19 31 43" src="https://user-images.githubusercontent.com/318083/46427996-1c84c680-c743-11e8-8364-c79f2e2c2bf1.png">
